### PR TITLE
增加插件、配置模块

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ wget-log*
 client/mic_array
 login/wxqr.png
 .idea/
+sftp-config.json

--- a/client/app_utils.py
+++ b/client/app_utils.py
@@ -100,7 +100,6 @@ def wechatUser(profile, wxbot, SUBJECT="", BODY="",
             for fpath in IMAGE_LIST:
                 wxbot.send_img_msg_by_uid(fpath, user_id)
             return True
-            return True
         except Exception as e:
             _logger.error(e)
             return False

--- a/client/brain.py
+++ b/client/brain.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8-*-
 from __future__ import absolute_import
 import logging
-import pkgutil
-from . import dingdangpath
+from . import plugin_loader
+from . import config
 
 
 class Brain(object):
 
-    def __init__(self, mic, profile):
+    def __init__(self, mic):
         """
         Instantiates a new Brain object, which cross-references user
         input with a list of plugins. Note that the order of brain.plugins
@@ -21,65 +21,9 @@ class Brain(object):
         """
 
         self.mic = mic
-        self.profile = profile
-        (self.plugins, self.exclude_plugins) = self.get_plugins()
+        self.plugins = plugin_loader.get_plugins()
         self._logger = logging.getLogger(__name__)
         self.handling = False
-
-    @classmethod
-    def get_plugins(cls):
-        """
-        Dynamically loads all the plugins in the plugins folder and sorts
-        them by the PRIORITY key. If no PRIORITY is defined for a given
-        plugin, a priority of 0 is assumed.
-        """
-
-        logger = logging.getLogger(__name__)
-        locations = [
-            dingdangpath.PLUGIN_PATH,
-            dingdangpath.CONTRIB_PATH,
-            dingdangpath.CUSTOM_PATH
-        ]
-        logger.debug("Looking for plugins in: %s",
-                     ', '.join(["'%s'" % location for location in locations]))
-        plugins = []
-        exclude_plugins = []
-        # plugins that are not allow to be call via Wechat or Email
-        thirdparty_exclude_plugins = ['NetEaseMusic']
-        for finder, name, ispkg in pkgutil.walk_packages(locations):
-            try:
-                loader = finder.find_module(name)
-                mod = loader.load_module(name)
-            except Exception:
-                logger.warning("Skipped plugin '%s' due to an error.", name,
-                               exc_info=True)
-            else:
-                if hasattr(mod, 'WORDS'):
-                    logger.debug("Found plugin '%s' with words: %r", name,
-                                 mod.WORDS)
-                    plugins.append(mod)
-                    if name in thirdparty_exclude_plugins:
-                        exclude_plugins.append(mod)
-                else:
-                    logger.warning("Skipped plugin '%s' because it misses " +
-                                   "the WORDS constant.", name)
-        plugins.sort(key=lambda mod: mod.PRIORITY if hasattr(mod, 'PRIORITY')
-                     else 0, reverse=True)
-        return (plugins, exclude_plugins)
-
-    def isEnabled(self, plugin):
-        """
-        whether a plugin is enabled.
-        """
-        if plugin is None:
-            return False
-        if not hasattr(plugin, 'SLUG'):
-            return True
-        slug = plugin.SLUG
-        if slug in self.profile and 'enable' in self.profile[slug]:
-            return self.profile[slug]['enable']
-        else:
-            return True
 
     def query(self, texts, wxbot=None, thirdparty_call=False):
         """
@@ -87,27 +31,28 @@ class Brain(object):
         each candidate plugin's isValid function.
 
         Arguments:
-        text -- user input, typically speech, to be parsed by a plugin
-        send_wechat -- also send the respondsed result to wechat
+        texts -- user input, typically speech, to be parsed by a plugin
+        wxbot -- also send the respondsed result to wechat
+        thirdparty_call -- call from wechat or email
         """
-        if thirdparty_call:
-            # check whether plugin is not allow to be call by thirdparty
-            for plugin in self.exclude_plugins:
-                for text in texts:
-                    if plugin.isValid(text):
-                        self.mic.say(u"抱歉，该功能暂时只能通过语音" +
-                                     "命令开启。请试试唤醒我后直接" +
-                                     "对我说\"%s\"" % text)
-                        return
 
         for plugin in self.plugins:
             for text in texts:
-                if plugin.isValid(text) and self.isEnabled(plugin):
+                if plugin.isValid(text):
+
+                    # check whether plugin is not allow to be call by thirdparty
+                    if thirdparty_call and plugin_loader.check_thirdparty_exclude(plugin):
+                        self.mic.say(u'抱歉，该功能暂时只能通过语音' +
+                                     u'命令开启。请试试唤醒我后直接' +
+                                     u'对我说"%s"' % text)
+                        return
+
                     self._logger.debug("'%s' is a valid phrase for plugin " +
                                        "'%s'", text, plugin.__name__)
+                    continueHandle = False
                     try:
                         self.handling = True
-                        plugin.handle(text, self.mic, self.profile, wxbot)
+                        continueHandle = plugin.handle(text, self.mic, config.get(), wxbot)
                         self.handling = False
                     except Exception:
                         self._logger.error('Failed to execute plugin',
@@ -119,6 +64,8 @@ class Brain(object):
                                            "plugin '%s' completed", text,
                                            plugin.__name__)
                     finally:
-                        return
+                        self.mic.stop_passive = False
+                        if not continueHandle:
+                            return
         self._logger.debug("No plugin was able to handle any of these " +
                            "phrases: %r", texts)

--- a/client/config.py
+++ b/client/config.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8-*-
+import yaml
+import logging
+import os
+from . import dingdangpath
+
+_logger = logging.getLogger(__name__)
+_config = {}
+
+
+def init(config_name='profile.yml'):
+    # Create config dir if it does not exist yet
+    if not os.path.exists(dingdangpath.CONFIG_PATH):
+        try:
+            os.makedirs(dingdangpath.CONFIG_PATH)
+        except OSError:
+            _logger.error("Could not create config dir: '%s'",
+                          dingdangpath.CONFIG_PATH, exc_info=True)
+            raise
+
+    # Check if config dir is writable
+    if not os.access(dingdangpath.CONFIG_PATH, os.W_OK):
+        _logger.critical("Config dir %s is not writable. Dingdang " +
+                         "won't work correctly.",
+                         dingdangpath.CONFIG_PATH)
+
+    config_file = dingdangpath.config(config_name)
+    global _config
+
+    # Read config
+    _logger.debug("Trying to read config file: '%s'", config_file)
+    try:
+        with open(config_file, "r") as f:
+            _config = yaml.safe_load(f)
+    except OSError:
+        _logger.error("Can't open config file: '%s'", config_file)
+        raise
+
+
+def has(item):
+    return item in _config
+
+
+def get(item='', default=None):
+    if not item:
+        return _config
+    try:
+        return _config[item]
+    except KeyError:
+        _logger.warning("%s not specified in profile, defaulting to '%s'",
+                        item, default)
+        return default

--- a/client/conversation.py
+++ b/client/conversation.py
@@ -1,45 +1,45 @@
 # -*- coding: utf-8-*-
 from __future__ import absolute_import
 import logging
+import time
 from .notifier import Notifier
 from .brain import Brain
-import time
+from . import plugin_loader
+from . import config
 
 
 class Conversation(object):
 
-    def __init__(self, persona, mic, profile):
+    def __init__(self, persona, mic):
         self._logger = logging.getLogger(__name__)
         self.persona = persona
         self.mic = mic
-        self.profile = profile
-        self.brain = Brain(mic, profile)
-        self.notifier = Notifier(profile, self.brain)
+        self.brain = Brain(mic)
+        self.notifier = Notifier(config.get(), self.brain)
         self.wxbot = None
 
-    def is_proper_time(self):
+    @staticmethod
+    def is_proper_time():
         """
         whether it's the proper time to gather
         notifications without disturb user
         """
-        if 'do_not_bother' not in self.profile:
+        if not config.has('do_not_bother'):
             return True
+        bother_profile = config.get('do_not_bother')
+        if not bother_profile['enable']:
+            return True
+        if 'since' not in bother_profile or 'till' not in bother_profile:
+            return True
+
+        since = bother_profile['since']
+        till = bother_profile['till']
+        current = time.localtime(time.time()).tm_hour
+        if till > since:
+            return current not in range(since, till)
         else:
-            if self.profile['do_not_bother']['enable']:
-                if 'since' not in self.profile['do_not_bother'] or \
-                   'till' not in self.profile['do_not_bother']:
-                    return True
-                else:
-                    since = self.profile['do_not_bother']['since']
-                    till = self.profile['do_not_bother']['till']
-                    current = time.localtime(time.time()).tm_hour
-                    if till > since:
-                        return current not in range(since, till)
-                    else:
-                        return not (current in range(since, 25) or
-                                    current in range(-1, till))
-            else:
-                return True
+            return not (current in range(since, 25) or
+                        current in range(-1, till))
 
     def handleForever(self):
         """
@@ -76,18 +76,42 @@ class Conversation(object):
                 self._logger.debug("Skip passive listening")
                 if not self.mic.chatting_mode:
                     self.mic.skip_passive = False
+                continue
 
             self._logger.debug("Started to listen actively with threshold: %r",
                                threshold)
+
+            # run plugins before listen
+            for plugin in plugin_loader.get_plugins_before_listen():
+                continueHandle = False
+                try:
+                    continueHandle = plugin.beforeListen(self.mic, config.get(), self.wxbot)
+                except Exception:
+                    self._logger.error("plugin '%s' run error", plugin.__name__,
+                                       exc_info=True)
+                finally:
+                    if not continueHandle:
+                        break
+
             input = self.mic.activeListenToAllOptions(threshold)
             self._logger.debug("Stopped to listen actively with threshold: %r",
                                threshold)
+
+            # run plugins after listen
+            for plugin in plugin_loader.get_plugins_after_listen():
+                continueHandle = False
+                try:
+                    continueHandle = plugin.afterListen(self.mic, config.get(), self.wxbot)
+                except Exception:
+                    self._logger.error("plugin '%s' run error", plugin.__name__,
+                                       exc_info=True)
+                finally:
+                    if not continueHandle:
+                        break
+
             if input:
                 self.brain.query(input, self.wxbot)
-            elif 'shut_up_if_no_input' in self.profile:
-                if not self.profile['shut_up_if_no_input']:
-                    self.mic.say(u"什么?")
-                else:
-                    self._logger.debug("Active Listen return empty")
+            elif config.get('shut_up_if_no_input', False):
+                self._logger.info("Active Listen return empty")
             else:
                 self.mic.say(u"什么?")

--- a/client/conversation.py
+++ b/client/conversation.py
@@ -85,10 +85,11 @@ class Conversation(object):
             for plugin in plugin_loader.get_plugins_before_listen():
                 continueHandle = False
                 try:
-                    continueHandle = plugin.beforeListen(self.mic, config.get(), self.wxbot)
+                    continueHandle = plugin.beforeListen(
+                        self.mic, config.get(), self.wxbot)
                 except Exception:
-                    self._logger.error("plugin '%s' run error", plugin.__name__,
-                                       exc_info=True)
+                    self._logger.error("plugin '%s' run error",
+                                       plugin.__name__, exc_info=True)
                 finally:
                     if not continueHandle:
                         break
@@ -101,10 +102,11 @@ class Conversation(object):
             for plugin in plugin_loader.get_plugins_after_listen():
                 continueHandle = False
                 try:
-                    continueHandle = plugin.afterListen(self.mic, config.get(), self.wxbot)
+                    continueHandle = plugin.afterListen(
+                        self.mic, config.get(), self.wxbot)
                 except Exception:
-                    self._logger.error("plugin '%s' run error", plugin.__name__,
-                                       exc_info=True)
+                    self._logger.error("plugin '%s' run error",
+                                       plugin.__name__, exc_info=True)
                 finally:
                     if not continueHandle:
                         break

--- a/client/local_mic.py
+++ b/client/local_mic.py
@@ -15,7 +15,7 @@ except NameError:
 class Mic:
     prev = None
 
-    def __init__(self, config, speaker, passive_stt_engine, active_stt_engine):
+    def __init__(self, speaker, passive_stt_engine, active_stt_engine):
         self.stop_passive = False
         self.skip_passive = False
         self.chatting_mode = False

--- a/client/mic.py
+++ b/client/mic.py
@@ -13,29 +13,26 @@ import pyaudio
 from . import dingdangpath
 from . import mute_alsa
 from .app_utils import wechatUser
+from . import plugin_loader
+from . import config
 
 
 class Mic:
     speechRec = None
     speechRec_persona = None
 
-    def __init__(self, profile, speaker, passive_stt_engine,
-                 active_stt_engine):
+    def __init__(self, speaker, passive_stt_engine, active_stt_engine):
         """
         Initiates the pocketsphinx instance.
 
         Arguments:
-        profile -- config profile
         speaker -- handles platform-independent audio output
         passive_stt_engine -- performs STT while Dingdang is in passive listen
                               mode
         acive_stt_engine -- performs STT while Dingdang is in active listen
                             mode
         """
-        self.profile = profile
-        self.robot_name = u'叮当'
-        if 'robot_name_cn' in profile:
-            self.robot_name = profile['robot_name_cn']
+        self.robot_name = config.get('robot_name_cn', u'叮当')
         self._logger = logging.getLogger(__name__)
         self.speaker = speaker
         self.wxbot = None
@@ -147,7 +144,7 @@ class Mic:
         frames = []
 
         # stores the lastN score values
-        lastN = [i for i in range(30)]
+        lastN = list(range(30))
 
         didDetect = False
 
@@ -196,7 +193,7 @@ class Mic:
 
         # no use continuing if no flag raised
         if not didDetect:
-            self._logger.debug("没接收到唤醒指令")
+            self._logger.debug(u"没接收到唤醒指令")
             try:
                 # self.stop_passive = False
                 stream.stop_stream()
@@ -204,7 +201,7 @@ class Mic:
             except Exception as e:
                 self._logger.debug(e)
                 pass
-            return (None, None)
+            return None, None
 
         # cutoff any recording before this disturbance was detected
         frames = frames[-20:]
@@ -236,9 +233,9 @@ class Mic:
 
         if transcribed is not None and \
            any(PERSONA in phrase for phrase in transcribed):
-            return (THRESHOLD, PERSONA)
+            return THRESHOLD, PERSONA
 
-        return (False, transcribed)
+        return False, transcribed
 
     def activeListen(self, THRESHOLD=None, LISTEN=True, MUSIC=False):
         """
@@ -274,12 +271,10 @@ class Mic:
                                   input=True,
                                   frames_per_buffer=CHUNK)
 
-        self.speaker.play(dingdangpath.data('audio', 'beep_hi.wav'))
-
         frames = []
         # increasing the range # results in longer pause after command
         # generation
-        lastN = [THRESHOLD * 1.2 for i in range(40)]
+        lastN = [THRESHOLD * 1.2] * 40
 
         for i in range(0, RATE / CHUNK * LISTEN_TIME):
             try:
@@ -298,8 +293,6 @@ class Mic:
             except Exception as e:
                 self._logger.error(e)
                 continue
-
-        self.speaker.play(dingdangpath.data('audio', 'beep_lo.wav'))
 
         # save the audio data
         try:
@@ -326,7 +319,7 @@ class Mic:
         self._logger.info(u"机器人说：%s" % phrase)
         self.stop_passive = True
         if self.wxbot is not None:
-            wechatUser(self.profile, self.wxbot, "%s: %s" %
+            wechatUser(config.get(), self.wxbot, "%s: %s" %
                        (self.robot_name, phrase), "")
         # incase calling say() method which
         # have not implement cache feature yet.

--- a/client/mic.py
+++ b/client/mic.py
@@ -13,7 +13,6 @@ import pyaudio
 from . import dingdangpath
 from . import mute_alsa
 from .app_utils import wechatUser
-from . import plugin_loader
 from . import config
 
 

--- a/client/notifier.py
+++ b/client/notifier.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8-*-
 from __future__ import absolute_import
-import Queue
 import atexit
 from .plugins import Email
 from apscheduler.schedulers.background import BackgroundScheduler
 import logging
 from . import app_utils
 import time
+import sys
+if sys.version_info < (3, 0):
+    import Queue as queue  # Python 2
+else:
+    import queue  # Python 3
 
 
 class Notifier(object):
@@ -22,7 +26,7 @@ class Notifier(object):
 
     def __init__(self, profile, brain):
         self._logger = logging.getLogger(__name__)
-        self.q = Queue.Queue()
+        self.q = queue.Queue()
         self.profile = profile
         self.notifiers = []
         self.brain = brain
@@ -86,7 +90,7 @@ class Notifier(object):
         try:
             notif = self.q.get(block=False)
             return notif
-        except Queue.Empty:
+        except queue.Empty:
             return None
 
     def getAllNotifications(self):

--- a/client/plugin_loader.py
+++ b/client/plugin_loader.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8-*-
+from __future__ import absolute_import
+import logging
+import pkgutil
+from . import dingdangpath
+from . import config
+
+
+_logger = logging.getLogger(__name__)
+_has_init = False
+
+# plugins run at query
+_plugins_query = []
+
+# plugins run at before listen
+_plugins_before_listen = []
+
+# plugins run at after listen
+_plugins_after_listen = []
+
+_thirdparty_exclude_plugins = {'netease_music'}
+
+
+def init_plugins():
+    """
+    Dynamically loads all the plugins in the plugins folder and sorts
+    them by the PRIORITY key. If no PRIORITY is defined for a given
+    plugin, a priority of 0 is assumed.
+    """
+
+    global _has_init
+    locations = [
+        dingdangpath.PLUGIN_PATH,
+        dingdangpath.CONTRIB_PATH,
+        dingdangpath.CUSTOM_PATH
+    ]
+    _logger.debug("Looking for plugins in: %s",
+                  ', '.join(["'%s'" % location for location in locations]))
+
+    global _plugins_query, _plugins_before_listen, _plugins_after_listen
+    nameSet = set()
+
+    # plugins that are not allow to be call via Wechat or Email
+    for finder, name, ispkg in pkgutil.walk_packages(locations):
+        try:
+            loader = finder.find_module(name)
+            mod = loader.load_module(name)
+        except Exception:
+            _logger.warning("Skipped plugin '%s' due to an error.", name,
+                            exc_info=True)
+            continue
+
+        # check slug
+        if not hasattr(mod, 'SLUG'):
+            mod.SLUG = name
+
+        # check conflict
+        if mod.SLUG in nameSet:
+            _logger.warning("plugin '%s' SLUG(%s) has repetition", name,
+                            mod.SLUG)
+            continue
+        nameSet.add(mod.SLUG)
+
+        # whether a plugin is enabled
+        if config.has(mod.SLUG) and 'enable' in config.get(mod.SLUG):
+            if not config.get(mod.SLUG)['enable']:
+                _logger.info("plugin '%s' is disabled", name)
+                continue
+
+        # plugins run at query
+        if hasattr(mod, 'WORDS'):
+            if not hasattr(mod, 'handle') or not hasattr(mod, 'isValid'):
+                _logger.debug("Query plugin '%s' missing handle or isValid",
+                              name)
+            else:
+                _logger.debug("Found query plugin '%s' with words: %r",
+                              name, mod.WORDS)
+                _plugins_query.append(mod)
+
+        # plugins run before listen
+        if hasattr(mod, 'beforeListen'):
+            _logger.debug("Found before-listen plugin '%s'", name)
+            _plugins_before_listen.append(mod)
+
+        # plugins run after listen
+        if hasattr(mod, 'afterListen'):
+            _logger.debug("Found after-listen plugin '%s'", name)
+            _plugins_after_listen.append(mod)
+
+    def sort_priority(m):
+        if hasattr(m, 'PRIORITY'):
+            return m.PRIORITY
+        return 0
+    _plugins_query.sort(key=sort_priority, reverse=True)
+    _has_init = True
+
+
+def get_plugins():
+    if not _has_init:
+        init_plugins()
+    return _plugins_query
+
+
+def get_plugins_before_listen():
+    if not _has_init:
+        init_plugins()
+    return _plugins_before_listen
+
+
+def get_plugins_after_listen():
+    if not _has_init:
+        init_plugins()
+    return _plugins_after_listen
+
+
+def check_thirdparty_exclude(mod):
+    if mod.SLUG in _thirdparty_exclude_plugins:
+        return False
+    return True

--- a/client/plugins/Time.py
+++ b/client/plugins/Time.py
@@ -37,4 +37,4 @@ def isValid(text):
         Arguments:
         text -- user-input, typically transcribed speech
     """
-    return any(word in text for word in ["时间", "几点"])
+    return any(word in text for word in [u"时间", u"几点"])

--- a/client/plugins/Unclear.py
+++ b/client/plugins/Unclear.py
@@ -2,6 +2,7 @@
 from sys import maxint
 import random
 from client.robot import get_robot_by_slug
+from client import dingdangpath
 
 WORDS = []
 PRIORITY = -(maxint + 1)
@@ -38,3 +39,11 @@ def handle(text, mic, profile, wxbot=None):
 
 def isValid(text):
     return True
+
+
+def beforeListen(mic, profile, wxbot=None):
+    mic.play(dingdangpath.data('audio', 'beep_hi.wav'))
+
+
+def afterListen(mic, profile, wxbot=None):
+    mic.play(dingdangpath.data('audio', 'beep_lo.wav'))

--- a/client/test_mic.py
+++ b/client/test_mic.py
@@ -29,5 +29,5 @@ class Mic:
         self.idx += 1
         return input
 
-    def say(self, phrase, OPTIONS=None):
+    def say(self, phrase, OPTIONS=None, cache=False):
         self.outputs.append(phrase)

--- a/client/tts.py
+++ b/client/tts.py
@@ -27,7 +27,6 @@ from abc import ABCMeta, abstractmethod
 from uuid import getnode as get_mac
 
 import argparse
-import yaml
 
 from . import diagnose
 from . import dingdangpath

--- a/client/tts.py
+++ b/client/tts.py
@@ -31,6 +31,7 @@ import yaml
 
 from . import diagnose
 from . import dingdangpath
+from . import config
 
 try:
     import gtts
@@ -59,8 +60,9 @@ class AbstractTTSEngine(object):
 
     @classmethod
     def get_instance(cls):
-        config = cls.get_config()
-        instance = cls(**config)
+        param = cls.get_config()
+        print(param)
+        instance = cls(**param)
         return instance
 
     @classmethod
@@ -141,6 +143,10 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
                 else:
                     os.remove(tmpfile)
 
+    def get_speech(self, phrase):
+        # The subclass needs to implement
+        return None
+
 
 class SimpleMp3Player(AbstractMp3TTSEngine):
     """
@@ -161,7 +167,7 @@ class BaiduTTS(AbstractMp3TTSEngine):
     使用百度语音合成技术
     要使用本模块, 首先到 yuyin.baidu.com 注册一个开发者账号,
     之后创建一个新应用, 然后在应用管理的"查看key"中获得 API Key 和 Secret Key
-    填入 profile.xml 中.
+    填入 profile.yml 中.
     ...
         baidu_yuyin: 'AIzaSyDoHmTEToZUQrltmORWS4Ott0OHVA62tw8'
             api_key: 'LMFYhLdXSSthxCNLR7uxFszQ'
@@ -171,7 +177,8 @@ class BaiduTTS(AbstractMp3TTSEngine):
 
     SLUG = "baidu-tts"
 
-    def __init__(self, api_key, secret_key, per=0):
+    def __init__(self, api_key, secret_key, per=0, **args):
+        super(self.__class__, self).__init__()
         self._logger = logging.getLogger(__name__)
         self.api_key = api_key
         self.secret_key = secret_key
@@ -180,24 +187,8 @@ class BaiduTTS(AbstractMp3TTSEngine):
 
     @classmethod
     def get_config(cls):
-        # FIXME: Replace this as soon as we have a config module
-        config = {}
         # Try to get baidu_yuyin config from config
-        profile_path = dingdangpath.config('profile.yml')
-        if os.path.exists(profile_path):
-            with open(profile_path, 'r') as f:
-                profile = yaml.safe_load(f)
-                if 'baidu_yuyin' in profile:
-                    if 'api_key' in profile['baidu_yuyin']:
-                        config['api_key'] = \
-                            profile['baidu_yuyin']['api_key']
-                    if 'secret_key' in profile['baidu_yuyin']:
-                        config['secret_key'] = \
-                            profile['baidu_yuyin']['secret_key']
-                    if 'per' in profile['baidu_yuyin']:
-                        config['per'] = \
-                            profile['baidu_yuyin']['per']
-        return config
+        return config.get('baidu_yuyin', {})
 
     @classmethod
     def is_available(cls):
@@ -270,29 +261,20 @@ class BaiduTTS(AbstractMp3TTSEngine):
 class IFlyTekTTS(AbstractMp3TTSEngine):
     """
     使用讯飞的语音合成技术
-    要使用本模块, 请先在 profile.xml 中启用本模块并选择合适的发音人.
+    要使用本模块, 请先在 profile.yml 中启用本模块并选择合适的发音人.
     """
 
     SLUG = "iflytek-tts"
 
-    def __init__(self, vid='60170'):
+    def __init__(self, vid='60170', **args):
+        super(self.__class__, self).__init__()
         self._logger = logging.getLogger(__name__)
         self.vid = vid
 
     @classmethod
     def get_config(cls):
-        # FIXME: Replace this as soon as we have a config module
-        config = {}
         # Try to get iflytek_yuyin config from config
-        profile_path = dingdangpath.config('profile.yml')
-        if os.path.exists(profile_path):
-            with open(profile_path, 'r') as f:
-                profile = yaml.safe_load(f)
-                if 'iflytek_yuyin' in profile:
-                    if 'vid' in profile['iflytek_yuyin']:
-                        config['vid'] = \
-                            profile['iflytek_yuyin']['vid']
-        return config
+        return config.get('iflytek_yuyin', {})
 
     @classmethod
     def is_available(cls):
@@ -326,12 +308,13 @@ class IFlyTekTTS(AbstractMp3TTSEngine):
 class ALiBaBaTTS(AbstractMp3TTSEngine):
     """
     使用阿里云的语音合成技术
-    要使用本模块, 请先在 profile.xml 中启用本模块并选择合适的发音人.
+    要使用本模块, 请先在 profile.yml 中启用本模块并选择合适的发音人.
     """
 
     SLUG = "ali-tts"
 
-    def __init__(self, ak_id, ak_secret, voice_name='xiaoyun'):
+    def __init__(self, ak_id, ak_secret, voice_name='xiaoyun', **args):
+        super(self.__class__, self).__init__()
         self._logger = logging.getLogger(__name__)
         self.ak_id = ak_id
         self.ak_secret = ak_secret
@@ -339,24 +322,8 @@ class ALiBaBaTTS(AbstractMp3TTSEngine):
 
     @classmethod
     def get_config(cls):
-        # FIXME: Replace this as soon as we have a config module
-        config = {}
         # Try to get ali_yuyin config from config
-        profile_path = dingdangpath.config('profile.yml')
-        if os.path.exists(profile_path):
-            with open(profile_path, 'r') as f:
-                profile = yaml.safe_load(f)
-                if 'ali_yuyin' in profile:
-                    if 'ak_id' in profile['ali_yuyin']:
-                        config['ak_id'] = \
-                            profile['ali_yuyin']['ak_id']
-                    if 'ak_secret' in profile['ali_yuyin']:
-                        config['ak_secret'] = \
-                            profile['ali_yuyin']['ak_secret']
-                    if 'voice_name' in profile['ali_yuyin']:
-                        config['voice_name'] = \
-                            profile['ali_yuyin']['voice_name']
-        return config
+        return config.get('ali_yuyin', {})
 
     @classmethod
     def is_available(cls):
@@ -425,7 +392,7 @@ class GoogleTTS(AbstractMp3TTSEngine):
 
     SLUG = "google-tts"
 
-    def __init__(self, language='en'):
+    def __init__(self, language='en', **args):
         super(self.__class__, self).__init__()
         self.language = language
 
@@ -437,19 +404,8 @@ class GoogleTTS(AbstractMp3TTSEngine):
 
     @classmethod
     def get_config(cls):
-        # FIXME: Replace this as soon as we have a config module
-        config = {}
-        # HMM dir
-        # Try to get hmm_dir from config
-        profile_path = dingdangpath.config('profile.yml')
-        if os.path.exists(profile_path):
-            with open(profile_path, 'r') as f:
-                profile = yaml.safe_load(f)
-                if ('google_yuyin' in profile and
-                   'language' in profile['google_yuyin']):
-                    config['language'] = profile['google_yuyin']['language']
-
-        return config
+        # Try to get google_yuyin from config
+        return config.get('google_yuyin', {})
 
     @property
     def languages(self):

--- a/client/vocabcompiler.py
+++ b/client/vocabcompiler.py
@@ -18,8 +18,8 @@ import shutil
 from abc import ABCMeta, abstractmethod, abstractproperty
 import yaml
 
-from . import brain
 from . import dingdangpath
+from . import plugin_loader
 
 from .g2p import PhonetisaurusG2P
 try:
@@ -119,7 +119,7 @@ class AbstractVocabulary(object):
             vocabulary.
 
         """
-        return (self.compiled_revision == self.phrases_to_revision(phrases))
+        return self.compiled_revision == self.phrases_to_revision(phrases)
 
     def compile(self, phrases, force=False):
         """
@@ -519,7 +519,7 @@ def get_all_phrases():
     """
     phrases = []
 
-    plugins = brain.Brain.get_plugins()
+    plugins = plugin_loader.get_plugins()
     for plugin in plugins:
         phrases.extend(get_phrases_from_plugin(plugin))
 

--- a/dingdang.py
+++ b/dingdang.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import os
 import sys
 import logging
-import yaml
 import argparse
 import threading
 from client import tts
@@ -14,6 +13,7 @@ from client import dingdangpath
 from client import diagnose
 from client import WechatBot
 from client.conversation import Conversation
+from client import config
 
 # Add dingdangpath.LIB_PATH to sys.path
 sys.path.append(dingdangpath.LIB_PATH)
@@ -27,7 +27,7 @@ parser.add_argument('--diagnose', action='store_true',
                     help='Run diagnose and exit')
 parser.add_argument('--debug', action='store_true', help='Show debug messages')
 parser.add_argument('--info', action='store_true', help='Show info messages')
-parser.add_argument('--verbose', action='store_true',
+parser.add_argument('-v', '--verbose', action='store_true',
                     help='Directly print logs rather than writing to log file')
 args = parser.parse_args()
 
@@ -40,80 +40,36 @@ else:
 class Dingdang(object):
     def __init__(self):
         self._logger = logging.getLogger(__name__)
+        config.init()
 
-        # Create config dir if it does not exist yet
-        if not os.path.exists(dingdangpath.CONFIG_PATH):
-            try:
-                os.makedirs(dingdangpath.CONFIG_PATH)
-            except OSError:
-                self._logger.error("Could not create config dir: '%s'",
-                                   dingdangpath.CONFIG_PATH, exc_info=True)
-                raise
-
-        # Check if config dir is writable
-        if not os.access(dingdangpath.CONFIG_PATH, os.W_OK):
-            self._logger.critical("Config dir %s is not writable. Dingdang " +
-                                  "won't work correctly.",
-                                  dingdangpath.CONFIG_PATH)
-
-        config_file = dingdangpath.config('profile.yml')
-        # Read config
-        self._logger.debug("Trying to read config file: '%s'", config_file)
-        try:
-            with open(config_file, "r") as f:
-                self.config = yaml.safe_load(f)
-        except OSError:
-            self._logger.error("Can't open config file: '%s'", config_file)
-            raise
-
-        try:
-            stt_engine_slug = self.config['stt_engine']
-        except KeyError:
-            stt_engine_slug = 'sphinx'
-            logger.warning("stt_engine not specified in profile, defaulting " +
-                           "to '%s'", stt_engine_slug)
+        stt_engine_slug = config.get('stt_engine', 'sphinx')
         stt_engine_class = stt.get_engine_by_slug(stt_engine_slug)
 
-        try:
-            slug = self.config['stt_passive_engine']
-            stt_passive_engine_class = stt.get_engine_by_slug(slug)
-        except KeyError:
-            stt_passive_engine_class = stt_engine_class
+        slug = config.get('stt_passive_engine', stt_engine_slug)
+        stt_passive_engine_class = stt.get_engine_by_slug(slug)
 
-        try:
-            tts_engine_slug = self.config['tts_engine']
-        except KeyError:
-            tts_engine_slug = tts.get_default_engine_slug()
-            logger.warning("tts_engine not specified in profile, defaulting " +
-                           "to '%s'", tts_engine_slug)
+        tts_engine_slug = config.get('tts_engine', tts.get_default_engine_slug())
         tts_engine_class = tts.get_engine_by_slug(tts_engine_slug)
 
         # Initialize Mic
         self.mic = Mic(
-            self.config,
             tts_engine_class.get_instance(),
             stt_passive_engine_class.get_passive_instance(),
             stt_engine_class.get_active_instance())
 
     def start_wxbot(self):
-        print("请扫描如下二维码登录微信")
-        print("登录成功后，可以与自己的微信账号（不是文件传输助手）交互")
+        print(u"请扫描如下二维码登录微信")
+        print(u"登录成功后，可以与自己的微信账号（不是文件传输助手）交互")
         self.wxBot.run(self.mic)
 
     def run(self):
-        if 'first_name' in self.config:
-            salutation = (u"%s 我能为您做什么?"
-                          % self.config["first_name"])
-        else:
-            salutation = "主人，我能为您做什么?"
+        salutation = (u"%s，我能为您做什么?" % config.get("first_name", u'主人'))
 
-        persona = 'DINGDANG'
-        if 'robot_name' in self.config:
-            persona = self.config["robot_name"]
-        conversation = Conversation(persona, self.mic, self.config)
+        persona = config.get("robot_name", 'DINGDANG')
+        conversation = Conversation(persona, self.mic)
 
         # create wechat robot
-        if self.config['wechat']:
+        if config.get('wechat', False):
             self.wxBot = WechatBot.WechatBot(conversation.brain)
             self.wxBot.DEBUG = True
             self.wxBot.conf['qr'] = 'tty'
@@ -140,8 +96,8 @@ if __name__ == "__main__":
 
     if args.verbose:
         logging.basicConfig(
-            format='%(asctime)s %(filename)s[line:%(lineno)d] \
-        %(levelname)s %(message)s',
+            format='%(asctime)s %(filename)s[line:%(lineno)d] '
+                   + '%(levelname)s: %(message)s',
             level=logging.INFO)
     else:
         logging.basicConfig(
@@ -149,8 +105,8 @@ if __name__ == "__main__":
                 dingdangpath.TEMP_PATH, "dingdang.log"
             ),
             filemode="w",
-            format='%(asctime)s %(filename)s[line:%(lineno)d] \
-            %(levelname)s %(message)s',
+            format='%(asctime)s %(filename)s[line:%(lineno)d] '
+                   + '%(levelname)s: %(message)s',
             level=logging.INFO)
 
     logger = logging.getLogger()

--- a/dingdang.py
+++ b/dingdang.py
@@ -48,7 +48,8 @@ class Dingdang(object):
         slug = config.get('stt_passive_engine', stt_engine_slug)
         stt_passive_engine_class = stt.get_engine_by_slug(slug)
 
-        tts_engine_slug = config.get('tts_engine', tts.get_default_engine_slug())
+        tts_engine_slug = config.get('tts_engine',
+                                     tts.get_default_engine_slug())
         tts_engine_class = tts.get_engine_by_slug(tts_engine_slug)
 
         # Initialize Mic

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -16,8 +16,7 @@ class TestBrain():
     @staticmethod
     def _emptyBrain():
         mic = test_mic.Mic([])
-        profile = DEFAULT_PROFILE
-        return brain.Brain(mic, profile)
+        return brain.Brain(mic)
 
     def testSortByPriority(self):
         """Does Brain sort plugins by priority?"""

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -59,5 +59,3 @@ class TestPlugins():
         query = u"发送微信二维码"
         inputs = []
         self.runConversation(query, inputs, SendQR)
-
-        


### PR DESCRIPTION
1. 增加插件模块
   * 插件读取后存在模块内置变量中，使用时不需要重复加载
   * 扩充插件类型，原有插件叫query插件，增加before_listen以及after_listen插件，插件运行时机为开始聆听和结束聆听。并将播放滴的一声移入Unclear插件。给插件开发更大的想象空间。
   * 增加插件处理函数返回值，含义为返回True则不中断优先级更低的插件运行。
2. 增加配置模块
   启动一并读入内存，并只加载一次。项目中读取配置无需重新读入和传参。修改了tts中全部的FIX ME的地方。

改动较多，辛苦@wzpan 和各位review
