### PR TITLE
修复新类型插件无顺序问题，新增wav/mp3播放方式，修复讯飞语音

### DIFF
--- a/client/WechatBot.py
+++ b/client/WechatBot.py
@@ -6,8 +6,8 @@ import os
 from client.wxbot import WXBot
 
 from client import dingdangpath
-from client.tts import SimpleMp3Player
 from client.audio_utils import mp3_to_wav
+from client import play
 
 
 class WechatBot(WXBot):
@@ -37,8 +37,8 @@ class WechatBot(WXBot):
            (msg['to_user_id'] == self.my_account['UserName'] or
                 msg['to_user_id'] == u'filehelper')):
             from_user = profile['first_name'] + '说：'
+            msg_data = from_user + msg['content']['data']
             if msg['content']['type'] == 0:
-                msg_data = from_user + msg['content']['data']
                 if msg_data.startswith(profile['robot_name_cn']+": "):
                     return
                 if self.music_mode is not None:
@@ -62,8 +62,8 @@ class WechatBot(WXBot):
                             mic.say("什么？")
                 else:
                     # 播放语音
-                    player = SimpleMp3Player()
-                    player.play_mp3(mp3_file)
+                    player = play.get_music_manager()
+                    player.play_block(mp3_file)
         elif msg['msg_type_id'] == 4:
             if 'wechat_echo_text_friends' in profile and \
                (
@@ -82,5 +82,5 @@ class WechatBot(WXBot):
                  ) and msg['content']['type'] == 4:
                 mp3_file = os.path.join(dingdangpath.TEMP_PATH,
                                         'voice_%s.mp3' % msg['msg_id'])
-                player = SimpleMp3Player()
-                player.play_mp3(mp3_file)
+                player = play.get_music_manager()
+                player.play_block(mp3_file)

--- a/client/config.py
+++ b/client/config.py
@@ -37,6 +37,34 @@ def init(config_name='profile.yml'):
         raise
 
 
+def get_path(items, default=None):
+    global _config
+    curConfig = _config
+    if isinstance(items, str) and items[0] == '/':
+        items = items.split('/')[1:]
+    for key in items:
+        if key in curConfig:
+            curConfig = curConfig[key]
+        else:
+            _logger.warning("/%s not specified in profile, defaulting to "
+                            "'%s'", '/'.join(items), default)
+            return default
+    return curConfig
+
+
+def has_path(items):
+    global _config
+    curConfig = _config
+    if isinstance(items, str) and items[0] == '/':
+        items = items.split('/')[1:]
+    for key in items:
+        if key in curConfig:
+            curConfig = curConfig[key]
+        else:
+            return False
+    return True
+
+
 def has(item):
     return item in _config
 
@@ -44,6 +72,8 @@ def has(item):
 def get(item='', default=None):
     if not item:
         return _config
+    if item[0] == '/':
+        return get_path(item, default)
     try:
         return _config[item]
     except KeyError:

--- a/client/conversation.py
+++ b/client/conversation.py
@@ -4,7 +4,6 @@ import logging
 import time
 from .notifier import Notifier
 from .brain import Brain
-from . import plugin_loader
 from . import config
 
 
@@ -81,35 +80,9 @@ class Conversation(object):
             self._logger.debug("Started to listen actively with threshold: %r",
                                threshold)
 
-            # run plugins before listen
-            for plugin in plugin_loader.get_plugins_before_listen():
-                continueHandle = False
-                try:
-                    continueHandle = plugin.beforeListen(
-                        self.mic, config.get(), self.wxbot)
-                except Exception:
-                    self._logger.error("plugin '%s' run error",
-                                       plugin.__name__, exc_info=True)
-                finally:
-                    if not continueHandle:
-                        break
-
             input = self.mic.activeListenToAllOptions(threshold)
             self._logger.debug("Stopped to listen actively with threshold: %r",
                                threshold)
-
-            # run plugins after listen
-            for plugin in plugin_loader.get_plugins_after_listen():
-                continueHandle = False
-                try:
-                    continueHandle = plugin.afterListen(
-                        self.mic, config.get(), self.wxbot)
-                except Exception:
-                    self._logger.error("plugin '%s' run error",
-                                       plugin.__name__, exc_info=True)
-                finally:
-                    if not continueHandle:
-                        break
 
             if input:
                 self.brain.query(input, self.wxbot)

--- a/client/mic.py
+++ b/client/mic.py
@@ -10,11 +10,11 @@ import wave
 import audioop
 import time
 import pyaudio
-import threading
 from . import dingdangpath
 from . import mute_alsa
 from .app_utils import wechatUser
 from . import config
+from . import play
 
 
 class Mic:
@@ -49,6 +49,7 @@ class Mic:
             pass
         self._audio = pyaudio.PyAudio()
         self._logger.info("Initialization of PyAudio completed.")
+        self.sound = play.get_sound_manager(self._audio)
         self.stop_passive = False
         self.skip_passive = False
         self.chatting_mode = False
@@ -333,25 +334,7 @@ class Mic:
 
     def play(self, src):
         # play a voice
-
-        CHUNK = 1024
-
-        logging.debug("playing wave %s", src)
-        f = wave.open(src, "rb")
-        stream = self._audio.open(
-            format=self._audio.get_format_from_width(f.getsampwidth()),
-            channels=f.getnchannels(),
-            rate=f.getframerate(),
-            output=True)
-
-        data = f.readframes(CHUNK)
-        while data:
-            stream.write(data)
-            data = f.readframes(CHUNK)
-
-        stream.stop_stream()
-        stream.close()
+        self.sound.play_block(src)
 
     def play_no_block(self, src):
-        t = threading.Thread(target=self.play, args=(src,))
-        t.start()
+        self.sound.play(src)

--- a/client/mic.py
+++ b/client/mic.py
@@ -15,6 +15,7 @@ from . import mute_alsa
 from .app_utils import wechatUser
 from . import config
 from . import play
+from . import plugin_loader
 
 
 class Mic:
@@ -256,6 +257,7 @@ class Mic:
 
             Returns a list of the matching options or None
         """
+        self.beforeListenEvent()
 
         RATE = 16000
         CHUNK = 1024
@@ -277,7 +279,7 @@ class Mic:
         # generation
         lastN = [THRESHOLD * 1.2] * 40
 
-        for i in range(0, RATE / CHUNK * LISTEN_TIME):
+        for i in range(0, int(RATE / CHUNK * LISTEN_TIME)):
             try:
                 data = stream.read(CHUNK, exception_on_overflow=False)
                 frames.append(data)
@@ -295,6 +297,8 @@ class Mic:
                 self._logger.error(e)
                 continue
 
+        self.endListenEvent()
+
         # save the audio data
         try:
             stream.stop_stream()
@@ -311,8 +315,35 @@ class Mic:
             wav_fp.writeframes(''.join(frames))
             wav_fp.close()
             f.seek(0)
-            frames = []
             return self.active_stt_engine.transcribe(f)
+
+    def beforeListenEvent(self):
+        # run plugins before listen
+        for plugin in plugin_loader.get_plugins_before_listen():
+            continueHandle = False
+            try:
+                continueHandle = plugin.beforeListen(
+                    self, config.get(), self.wxbot)
+            except Exception:
+                self._logger.error("plugin '%s' run error",
+                                   plugin.__name__, exc_info=True)
+            finally:
+                if not continueHandle:
+                    break
+
+    def endListenEvent(self):
+        # run plugins after listen
+        for plugin in plugin_loader.get_plugins_after_listen():
+            continueHandle = False
+            try:
+                continueHandle = plugin.afterListen(
+                    self, config.get(), self.wxbot)
+            except Exception:
+                self._logger.error("plugin '%s' run error",
+                                   plugin.__name__, exc_info=True)
+            finally:
+                if not continueHandle:
+                    break
 
     def say(self, phrase,
             OPTIONS=" -vdefault+m3 -p 40 -s 160 --stdout > say.wav",

--- a/client/play.py
+++ b/client/play.py
@@ -1,0 +1,366 @@
+# -*- coding: utf-8-*-
+import subprocess
+import time
+
+import logging
+import wave
+import threading
+import tempfile
+try:
+    import pygame
+    pygame.mixer.init(frequency=16000)
+except ImportError:
+    pass
+
+_logger = logging.getLogger(__name__)
+_sound_instance = None
+_music_instance = None
+
+
+class AbstractSoundPlay(threading.Thread):
+
+    def __init__(self, **kwargs):
+        super(AbstractSoundPlay, self).__init__()
+
+    def play(self):
+        pass
+
+    def play_block(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def is_playing(self):
+        return False
+
+
+class AudioSoundPlay(AbstractSoundPlay):
+    SLUG = 'pyaudio'
+
+    def __init__(self, src, audio=None, **kwargs):
+        import pyaudio
+        super(AudioSoundPlay, self).__init__(**kwargs)
+        if not audio:
+            self.audio = pyaudio.PyAudio()
+        else:
+            self.audio = audio
+        self.src = src
+        self.playing = False
+        self.stop = False
+
+    def run(self):
+        # play a voice
+        CHUNK = 1024
+
+        _logger.debug("playing wave %s", self.src)
+        f = wave.open(self.src, "rb")
+        stream = self.audio.open(
+            format=self.audio.get_format_from_width(f.getsampwidth()),
+            channels=f.getnchannels(),
+            rate=f.getframerate(),
+            output=True)
+
+        self.playing = True
+        data = f.readframes(CHUNK)
+        while data and not self.stop:
+            stream.write(data)
+            data = f.readframes(CHUNK)
+
+        self.playing = False
+        stream.stop_stream()
+        stream.close()
+
+    def play(self):
+        self.start()
+
+    def play_block(self):
+        self.run()
+
+    def stop(self):
+        self.stop = True
+
+    def is_playing(self):
+        return self.playing
+
+
+class ShellSoundPlay(AbstractSoundPlay):
+    SLUG = 'aplay'
+
+    def __init__(self, src, **kwargs):
+        super(ShellSoundPlay, self).__init__(**kwargs)
+        self.src = src
+        self.playing = False
+        self.pipe = None
+
+    def run(self):
+        # play a voice
+        cmd = ['aplay', '-q', str(self.src)]
+        _logger.debug('Executing %s', ' '.join(cmd))
+
+        self.pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
+        self.playing = True
+        # while self.pipe.poll():
+        #     time.sleep(0.1)
+        self.pipe.wait()
+        self.playing = False
+        output = self.pipe.stdout.read()
+        if output:
+            _logger.debug("play Output was: '%s'", output)
+        error = self.pipe.stderr.read()
+        if error:
+            _logger.error("play error: '%s'", error)
+
+    def play(self):
+        self.start()
+
+    def play_block(self):
+        self.run()
+
+    def stop(self):
+        if self.pipe:
+            self.pipe.kill()
+
+    def is_playing(self):
+        return self.playing
+
+
+class AbstractMusicPlay(threading.Thread):
+
+    def __init__(self, **kwargs):
+        super(AbstractMusicPlay, self).__init__()
+
+    def play(self):
+        pass
+
+    def play_block(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def is_playing(self):
+        return False
+
+    def pause(self):
+        pass
+
+
+class ShellMusicPlay(AbstractMusicPlay):
+    SLUG = 'play'
+
+    def __init__(self, src, **kwargs):
+        super(ShellMusicPlay, self).__init__(**kwargs)
+        self.src = src
+        self.playing = False
+        self.pipe = None
+
+    def run(self):
+        cmd = ['play', str(self.src)]
+        _logger.debug('Executing %s', ' '.join(cmd))
+
+        with tempfile.TemporaryFile() as f:
+            self.pipe = subprocess.Popen(cmd, stdout=f, stderr=f)
+            self.playing = True
+            self.pipe.wait()
+            self.playing = False
+            f.seek(0)
+            output = f.read()
+            if output:
+                _logger.debug("play Output was: '%s'", output)
+
+    def play(self):
+        self.start()
+
+    def play_block(self):
+        self.run()
+
+    def stop(self):
+        if self.pipe:
+            self.pipe.kill()
+
+    def is_playing(self):
+        return self.playing
+
+
+class VlcMusicPlay(AbstractMusicPlay):
+    SLUG = 'vlc'
+
+    def __init__(self, src, **kwargs):
+        import vlc
+        super(VlcMusicPlay, self).__init__(**kwargs)
+        self.src = src
+        self.media = vlc.MediaPlayer(src)
+        self.played = False
+
+    def run(self):
+        pass
+
+    def play(self):
+        _logger.debug('vlc play %s', self.src)
+        self.played = True
+        self.media.play()
+
+    def play_block(self):
+        _logger.debug('vlc play_block %s', self.src)
+        self.media.play()
+        time.sleep(0.4)
+        while self.media.is_playing():
+            time.sleep(0.1)
+
+    def stop(self):
+        self.media.stop()
+
+    def is_playing(self):
+        return self.media.is_playing() == 1
+
+    def pause(self):
+        self.media.pause()
+
+    def wait(self):
+        if self.played:
+            time.sleep(0.4)
+            while self.media.is_playing():
+                time.sleep(0.1)
+
+
+class PyGameMusicPlay(AbstractMusicPlay):
+    SLUG = 'pygame'
+
+    def __init__(self, src, **kwargs):
+        import pygame
+        super(PyGameMusicPlay, self).__init__(**kwargs)
+        self.src = src
+        self.played = False
+        pygame.mixer.music.load(self.src)
+        self.paused = False
+
+    def run(self):
+        pass
+
+    def play(self):
+        _logger.debug('pygame play %s', self.src)
+        self.played = True
+        pygame.mixer.music.play()
+
+    def play_block(self):
+        _logger.debug('pygame play %s', self.src)
+        self.played = True
+        pygame.mixer.music.play()
+        pygame.time.delay(200)
+        while pygame.mixer.music.get_busy():
+            time.sleep(0.1)
+
+    def stop(self):
+        pygame.mixer.music.stop()
+
+    def is_playing(self):
+        return pygame.mixer.music.get_busy()
+
+    def pause(self):
+        if not self.played:
+            return
+        if not self.paused:
+            pygame.mixer.music.pause()
+            self.paused = True
+        else:
+            pygame.mixer.music.unpause()
+            self.paused = False
+
+    def wait(self):
+        if self.played:
+            pygame.time.delay(200)
+            while pygame.mixer.music.get_busy():
+                time.sleep(0.1)
+
+
+class Sound(object):
+
+    def __init__(self, slug, audio=None):
+        for sound_engine in get_subclasses(AbstractSoundPlay):
+            if hasattr(sound_engine, 'SLUG') and sound_engine.SLUG == slug:
+                self.slug = slug
+                self.sound_engine = sound_engine
+                break
+        else:
+            raise ValueError("No sound engine found for slug '%s'" % slug)
+        self.audio = audio
+        self.thread = None
+
+    def play(self, src):
+        self.thread = self.sound_engine(src, audio=self.audio)
+        self.thread.play()
+
+    def play_block(self, src):
+        t = self.sound_engine(src, audio=self.audio)
+        t.play_block()
+
+    def wait(self):
+        if self.thread:
+            self.thread.join()
+
+    def stop(self):
+        if self.thread and self.thread.is_playing():
+            self.thread.stop()
+
+
+class Music(object):
+
+    def __init__(self, slug):
+        for music_engine in get_subclasses(AbstractMusicPlay):
+            if hasattr(music_engine, 'SLUG') and music_engine.SLUG == slug:
+                self.slug = slug
+                self.music_engine = music_engine
+                break
+        else:
+            raise ValueError("No music engine found for slug '%s'" % slug)
+        self.thread = None
+
+    def play(self, src):
+        self.thread = self.music_engine(src)
+        self.thread.play()
+
+    def play_block(self, src):
+        t = self.music_engine(src)
+        t.play_block()
+
+    def wait(self):
+        if self.thread:
+            if hasattr(self.thread, 'wait'):
+                self.thread.wait()
+            else:
+                self.thread.join()
+
+    def stop(self):
+        if self.thread and self.thread.is_playing():
+            self.thread.stop()
+
+    def pause(self):
+        if self.thread:
+            self.thread.pause()
+
+
+def get_subclasses(cls):
+    subclasses = set()
+    for subclass in cls.__subclasses__():
+        subclasses.add(subclass)
+        subclasses.update(get_subclasses(subclass))
+    return subclasses
+
+
+def get_sound_manager(audio=None):
+    from . import config
+    global _sound_instance
+    if not _sound_instance:
+        _sound_instance = Sound(config.get('sound_engine', 'pyaudio'),
+                                audio=audio)
+    return _sound_instance
+
+
+def get_music_manager():
+    from . import config
+    global _music_instance
+    if not _music_instance:
+        _music_instance = Music(config.get('music_engine', 'play'))
+    return _music_instance

--- a/client/plugin_loader.py
+++ b/client/plugin_loader.py
@@ -92,6 +92,8 @@ def init_plugins():
             return m.PRIORITY
         return 0
     _plugins_query.sort(key=sort_priority, reverse=True)
+    _plugins_before_listen.sort(key=sort_priority, reverse=True)
+    _plugins_after_listen.sort(key=sort_priority, reverse=True)
     _has_init = True
 
 

--- a/client/plugins/Unclear.py
+++ b/client/plugins/Unclear.py
@@ -46,4 +46,4 @@ def beforeListen(mic, profile, wxbot=None):
 
 
 def afterListen(mic, profile, wxbot=None):
-    mic.play(dingdangpath.data('audio', 'beep_lo.wav'))
+    mic.play_no_block(dingdangpath.data('audio', 'beep_lo.wav'))

--- a/client/robot.py
+++ b/client/robot.py
@@ -169,7 +169,8 @@ class Emotibot(AbstractRobot):
                 if self.more:
                     datas = jsondata.get('data')
                     for data in datas:
-                        responds.append(data.get('value'))
+                        if data.get('type') == 'text':
+                            responds.append(data.get('value'))
                 else:
                     responds.append(jsondata.get('data')[0].get('value'))
                 result = '\n'.join(responds)

--- a/client/tts.py
+++ b/client/tts.py
@@ -97,8 +97,7 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
 
     def play_mp3(self, filename, remove=False):
         music = play.get_music_manager()
-        # music.play_block(filename)
-        music.play(filename)
+        music.play_block(filename)
 
     def removePunctuation(self, phrase):
         to_remove = [

--- a/client/tts.py
+++ b/client/tts.py
@@ -77,15 +77,25 @@ class AbstractTTSEngine(object):
         pass
 
     def play(self, filename):
-        cmd = ['aplay', str(filename)]
+        """
+        The method has deprecated, use 'mic.Mic.play' instead.
+        play wave by aplay
+        """
+        self._logger.warning("The 'play' method is deprecated, "
+                             "use 'mic.play' instead")
+        cmd = ['aplay', '-q', str(filename)]
         self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
                                                      for arg in cmd]))
-        with tempfile.TemporaryFile() as f:
-            subprocess.call(cmd, stdout=f, stderr=f)
-            f.seek(0)
-            output = f.read()
-            if output:
-                self._logger.debug("Output was: '%s'", output)
+
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        p.wait()
+        output = p.stdout.read()
+        if output:
+            self._logger.debug("play Output was: '%s'", output)
+        error = p.stderr.read()
+        if error:
+            self._logger.error("play error: '%s'", error)
 
 
 class AbstractMp3TTSEngine(AbstractTTSEngine):

--- a/dingdang.py
+++ b/dingdang.py
@@ -7,6 +7,7 @@ import sys
 import logging
 import argparse
 import threading
+import traceback
 from client import tts
 from client import stt
 from client import dingdangpath
@@ -128,8 +129,19 @@ if __name__ == "__main__":
 
     try:
         app = Dingdang()
-    except Exception:
-        logger.error("Error occured!", exc_info=True)
+    except:
+        logger.exception("Error occured!")
         sys.exit(1)
 
-    app.run()
+    try:
+        app.run()
+    except KeyboardInterrupt:
+        logger.info("dingdang get Keyboard Interrupt, exit.")
+        print("dingdang exit.")
+    except:
+        logger.exception("dingdang quit unexpectedly!")
+        if not args.verbose:
+            msg = traceback.format_exc()
+            print("** dingdang quit unexpectedly! ** ")
+            print(msg)
+        sys.exit(1)

--- a/dingdang.py
+++ b/dingdang.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
 
     try:
         app = Dingdang()
-    except:
+    except Exception:
         logger.exception("Error occured!")
         sys.exit(1)
 
@@ -138,7 +138,7 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         logger.info("dingdang get Keyboard Interrupt, exit.")
         print("dingdang exit.")
-    except:
+    except Exception:
         logger.exception("dingdang quit unexpectedly!")
         if not args.verbose:
             msg = traceback.format_exc()


### PR DESCRIPTION
1. 修复新类型插件无顺序问题
2. 引入play模块

   1. wav播放由原来的调用子进程aplay播放改为默认pyaudio直接播放，减少播放耗时。实际上测试大概只节约200ms左右。
   2. play模块支持aplay方式和pyaudoi方式播放wav文件，支持play方式、pygame方式、vlc方式播放MP3文件，配置见下。
   3. mp3默认还是通过shell调用play播放，但是可以配置通过pygame播放，实测速度有提高。

新增配置：
```
# wav声音播放配置
# 可选值：
# aplay         - 子进程aplay播放
# pyaudio       - pyaudio模块播放
sound_engine: pyaudio

# mp3文件播放配置
# 可选值：
# play          - 子进程play播放
# pygame        - pygame库播放(树莓派python默认自带，推荐配置)
# vlc           - vlc库播放(短音频可能播放有问题)
music_engine: pygame
```
安装vlc，不使用vlc配置的话不安装也可以：
```
apt-get install vlc
pip install python-vlc
```

3. 修复讯飞语音合成api
当前的讯飞api需要申请api_key，以及配置白名单

修改配置：
```
# 讯飞语音服务
# api_id 及 api_key 需前往
# http://www.xfyun.cn
# 注册获取（注意创建的是WebAPI应用）
# 然后将树莓派的ip地址添加进ip白名单
iflytek_yuyin:
    api_id: '***'
    api_key: '**********************'
    url: '' # 白名单ip中转服务器（可选）
    tts:
        api_id: '***' # 这项不填可以使用上层配置
        api_key: '**********************'
        voice_name: xiaoyan
        proxy: 'http://123.207.49.217:8028'
```
配置中增加tts专用api_key。其中proxy是http代理，需要自己搭建http正向代理服务器例如squid。上面的是我的服务器可以测试使用。

4. 小影机器人返回中url也会被读出来，将url过滤掉。
5. 恢复插件的before/end listen事件触发时机，修复了插件中没有滴的一声的问题。

PS：
1. 个人认为聆听结束的滴的一声一般不会特别在意，但是极为耗时（平均耗时1s左右，几乎超过一次http请求了），这里改为异步播放。提升整体响应速度。
2. 另外引入vlc播放mp3是因为vlc支持http等流播放，且支持暂停。意在后续修改网易云插件支持暂停等操作。当前网易云插件过于重，考虑引入音频播放事件监听，通过插件支持的方式修改网易云插件，而不是当前在插件中实现监听。