### PR TITLE
添加信号灯支持

### DIFF
--- a/client/conversation.py
+++ b/client/conversation.py
@@ -6,6 +6,7 @@ from .notifier import Notifier
 from .brain import Brain
 from . import plugin_loader
 from . import config
+from .drivers.pixels import Pixels
 
 
 class Conversation(object):
@@ -17,6 +18,15 @@ class Conversation(object):
         self.brain = Brain(mic)
         self.notifier = Notifier(config.get(), self.brain)
         self.wxbot = None
+
+        self.pixels = None
+        if config.has('signal_led'):
+            signal_led_profile = config.get('signal_led')
+            if signal_led_profile['enable'] and \
+                signal_led_profile['gpio_mode'] and \
+                    signal_led_profile['pin']:
+                self.pixels = Pixels(signal_led_profile['gpio_mode'],
+                                     signal_led_profile['pin'])
 
     @staticmethod
     def is_proper_time():
@@ -78,6 +88,8 @@ class Conversation(object):
                     self.mic.skip_passive = False
                 continue
 
+            if self.pixels:
+                self.pixels.wakeup()
             self._logger.debug("Started to listen actively with threshold: %r",
                                threshold)
 
@@ -111,9 +123,13 @@ class Conversation(object):
                     if not continueHandle:
                         break
 
+            if self.pixels:
+                self.pixels.think()
             if input:
                 self.brain.query(input, self.wxbot)
             elif config.get('shut_up_if_no_input', False):
                 self._logger.info("Active Listen return empty")
             else:
                 self.mic.say(u"什么?")
+            if self.pixels:
+                self.pixels.off()

--- a/client/drivers/pixels.py
+++ b/client/drivers/pixels.py
@@ -1,0 +1,98 @@
+import RPi.GPIO as GPIO
+import time
+import threading
+try:
+    import queue as Queue
+except ImportError:
+    import Queue as Queue
+
+
+class Pixels:
+    def __init__(self, gpio_mode, pin):
+        self.led_pin = pin
+        GPIO.setwarnings(False)
+        if gpio_mode == 'bcm':
+            GPIO.setmode(GPIO.BCM)
+        else:
+            GPIO.setmode(GPIO.BOARD)
+        GPIO.setup(pin, GPIO.OUT)
+
+        self.next = threading.Event()
+        self.queue = Queue.Queue()
+        self.thread = threading.Thread(target=self._run)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def wakeup(self, direction=0):
+        def f():
+            self._wakeup(direction)
+
+        self.next.set()
+        self.queue.put(f)
+
+    def listen(self):
+        self.next.set()
+        self.queue.put(self._listen)
+
+    def think(self):
+        self.next.set()
+        self.queue.put(self._think)
+
+    def speak(self):
+        self.next.set()
+        self.queue.put(self._speak)
+
+    def off(self):
+        self.next.set()
+        self.queue.put(self._off)
+
+    def _run(self):
+        while True:
+            func = self.queue.get()
+            func()
+
+    def _wakeup(self, direction=0):
+        GPIO.output(self.led_pin, GPIO.HIGH)
+
+    def _listen(self):
+        GPIO.output(self.led_pin, GPIO.HIGH)
+
+    def _think(self):
+        self.next.clear()
+        while not self.next.is_set():
+            GPIO.output(self.led_pin, GPIO.HIGH)
+            time.sleep(0.3)
+            GPIO.output(self.led_pin, GPIO.LOW)
+            time.sleep(0.3)
+
+    def _speak(self):
+        self.next.clear()
+        while not self.next.is_set():
+            GPIO.output(self.led_pin, GPIO.HIGH)
+            time.sleep(0.3)
+            GPIO.output(self.led_pin, GPIO.LOW)
+            time.sleep(0.3)
+
+        self._off()
+
+    def _off(self):
+        GPIO.output(self.led_pin, GPIO.LOW)
+
+
+if __name__ == '__main__':
+    while True:
+        try:
+            pixels = Pixels("bcm", 24)
+            pixels.wakeup()
+            time.sleep(3)
+            pixels.think()
+            time.sleep(3)
+            pixels.speak()
+            time.sleep(3)
+            pixels.off()
+            time.sleep(3)
+        except KeyboardInterrupt:
+            break
+
+    pixels.off()
+    time.sleep(1)

--- a/client/robot.py
+++ b/client/robot.py
@@ -55,7 +55,7 @@ class TulingRobot(AbstractRobot):
         if 'tuling' in self.profile:
             if 'tuling_key' in self.profile['tuling']:
                 tuling_key = \
-                        self.profile['tuling']['tuling_key']
+                    self.profile['tuling']['tuling_key']
         return tuling_key
 
     def chat(self, texts):
@@ -81,7 +81,7 @@ class TulingRobot(AbstractRobot):
             elif respond['code'] == 302000:
                 for k in respond['list']:
                     result = result + u"【" + k['source'] + u"】 " +\
-                             k['article'] + "\t" + k['detailurl'] + "\n"
+                        k['article'] + "\t" + k['detailurl'] + "\n"
             else:
                 result = respond['text'].replace('<br>', '  ')
                 result = result.replace(u'\xa0', u' ')
@@ -130,15 +130,15 @@ class Emotibot(AbstractRobot):
         if 'emotibot' in self.profile:
             if 'appid' in self.profile['emotibot']:
                 appid = \
-                        self.profile['emotibot']['appid']
+                    self.profile['emotibot']['appid']
             if 'location' in self.profile:
                 location = \
-                        self.profile['location']
+                    self.profile['location']
             else:
                 location = None
             if 'active_mode' in self.profile['emotibot']:
                 more = \
-                        self.profile['emotibot']['active_mode']
+                    self.profile['emotibot']['active_mode']
             else:
                 more = False
         return (appid, location, more)
@@ -200,7 +200,7 @@ class Emotibot(AbstractRobot):
                 else:
                     self.mic.say(u'抱歉，%s发送失败了！' % target, cache=True)
             else:
-                self.mic.say(result, cache=True)
+                self.mic.say(result)
             if result.endswith('?') or result.endswith(u'？') or \
                u'告诉我' in result or u'请回答' in result:
                 self.mic.skip_passive = True


### PR DESCRIPTION
1. 信号灯配置如下：
#信号灯
#将普通led接入树莓派GPIO， 唤醒后常亮，思考及说话时闪亮
signal_led:
    enable: true
    gpio_mode: "bcm" # "bcm" 或 "board"
    pin: 24 # led 正极接脚， 负极接GND

2. robot.py 中 去掉203行的缓存标识： self.mic.say(result, cache=True)， 因机器人回答的信息重复的很少，没必要句句缓存， 不然说的每句话都会缓存到temp文件夹， 时间久了很占空间，虽说有一句清空功能，但是同时把log也给清掉了。